### PR TITLE
Allow use with normal http server

### DIFF
--- a/test/assets/error.js
+++ b/test/assets/error.js
@@ -1,0 +1,1 @@
+console.log('I haz error'

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,57 @@
+var assert = require('assert');
+var vm = require('vm');
+
+var request = require('supertest');
+var after = require('after');
+var http = require('http');
+
+var enchilada = require('../');
+
+var server;
+
+test('setup normal http server', function(done) {
+    server = http.createServer(enchilada(__dirname + '/assets'));
+    server.listen(done);
+});
+
+test('basic without express', function(done) {
+    done = after(3, done);
+
+    request(server)
+    .get('/foo.js')
+    .end(function(err, res) {
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.headers['content-type'], 'application/javascript');
+
+        var sandbox = {
+            done: done,
+            assert: assert
+        };
+
+        var src = res.text;
+        vm.runInNewContext(src, sandbox);
+        done();
+    });
+});
+
+test('handle browserify errors', function(done) {
+    request(server)
+    .get('/error.js')
+    .end(function(err, res) {
+        assert.equal(res.statusCode, 500);
+        assert.equal(res.headers['content-type'], 'text/plain');
+        assert.ok(/Error/.test(res.text));
+        done();
+    });
+});
+
+test('handle missing file', function(done) {
+    request(server)
+    .get('/missing.js')
+    .end(function(err, res) {
+        assert.equal(res.statusCode, 404);
+        assert.equal(res.headers['content-type'], 'text/plain');
+        assert.equal(res.text, 'Not Found');
+        done();
+    });
+});


### PR DESCRIPTION
This modifies the handler to allow it to be used outside of an express/connect application (for example using the normal Node http server or a standalone router). It also adds tests to verify this behavior.

The code for sending the result is a little more verbose, since it cannot use any of the express helpers.
