### PR TITLE
Allow global transforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,11 @@ module.exports = function enchilada(opt) {
                 bundle.transform(transform)
             });
         }
+        if (opt.globalTransforms) {
+            opt.globalTransforms.forEach(function(transform) {
+                bundle.transform({ global: true }, transform)
+            });
+        }
         if (opt.externals) {
             opt.externals.forEach(function(external) {
                 bundle.external(external);


### PR DESCRIPTION
This patch adds a corresponding `globalTransforms` option that behaves just like the `transforms` option, except `{global: true}` is passed as the first argument to `bundle.transform()`

I'm not married to the implementation, but it seemed like the least intrusive both in exposed interface and required code.

It needs tests, which I'll write once we're sure it's a desired feature.

_(I want this functionality for [uglifyify](https://github.com/hughsk/uglifyify#global-transforms), but it's a browserify option that's generally useful)_
