### PR TITLE
Update convert-source-map to 1.1.1 to fix stack overflow issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "author": "Roman Shtylman <shtylman@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "mime": "1.2.11",
     "browserify": "4.1.9",
-    "filewatcher": "1.1.1",
-    "uglify-js": "2.4.13",
+    "convert-source-map": "1.1.1",
     "debug": "1.0.1",
-    "convert-source-map": "0.3.4"
+    "filewatcher": "1.1.1",
+    "mime": "1.2.11",
+    "uglify-js": "2.4.13"
   },
   "devDependencies": {
     "through": "2.3.4",


### PR DESCRIPTION
Unit tests pass:

```
[theo@MacBook-Pro node-enchilada (master)]$ npm run test

> enchilada@0.12.0 test /Volumes/sixfive-cs/node-enchilada
> mocha test/*.js

(node) child_process: options.customFds option is deprecated. Use options.stdio instead.

  ․ basic setup: 5ms
  ․ basic basic: 91ms
  ․ compress setup: 0ms
  ․ compress /foo.js - not entry: 109ms
  ․ routes setup: 1ms
  ․ routes /foo.js - should run: 39ms
  ․ routes /baz.js - entry: 52ms
  ․ routes /cats-module.js - should run: 40ms
  ․ routes /cats.js - entry: 45ms
  ․ server setup normal http server: 0ms
  ․ server basic without express: 36ms
  ․ server handle browserify errors: 15ms
  ․ server handle missing file: 2ms
  ․ sourcemap setup: 1ms
  ․ sourcemap basic: 48ms
  ․ sourcemap setup for compress: 1ms
  ․ sourcemap basic: 89ms
  ․ transforms setup: 0ms
  ․ transforms transform called: 34ms

  19 passing (624ms)

```