### PR TITLE
Add options to  prefix url

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = function enchilada(opt) {
     var generating = {};
     var maps = {}; // cache of sourcemaps
     var debug_opt = false || opt.debug;
+    var prefix = opt.prefix;
 
     var watch = !opt.cache;
     var watchCallback = opt.watchCallback;
@@ -64,6 +65,10 @@ module.exports = function enchilada(opt) {
 
     return function(req, res, next) {
         var req_path = req.path || url.parse(req.url).path;
+
+        if (prefix && 0 === req_path.indexOf(prefix)) {
+            req_path = req_path.substring(prefix.length);
+        }
 
         if (/.map.json$/.test(req_path) && maps[req_path]) {
             return res.json(maps[req_path]);


### PR DESCRIPTION
Simple option in order to allow prefix of url 
for example, with directory structure like 
/ 
/src 
/public/static

if you set an option prefix: "/static", you can serve the src directory
